### PR TITLE
Fix bitness-dependent IBI header output

### DIFF
--- a/ibize/blockstream.cpp
+++ b/ibize/blockstream.cpp
@@ -532,7 +532,7 @@ int CBlockStream::Create( char *filename )
 		return false;
 	}
 
-	fwrite( id_header, 1, sizeof(id_header), m_fileHandle );
+	fwrite( id_header, 1, strlen(id_header)+1, m_fileHandle );
 	fwrite( &version, 1, sizeof(version), m_fileHandle );
 
 	return true;


### PR DESCRIPTION
When IBIze outputs the IBI header, it calculates the number of required bytes by taking the size of a pointer. This differs between 32-bit (4 bytes) and 64-bit (8 bytes) systems, even though the file format itself prescribes 4 bytes. Modify the code to take the length of the string (including the terminating NUL byte) instead.