### PR TITLE
Make IBIze build on modern Linux and Mac OS systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
 cmake_minimum_required(VERSION 3.1)
 project(OpenJK-Tools)
 
-add_subdirectory(Ibize)
+add_subdirectory(ibize)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required(VERSION 3.1)
 project(OpenJK-Tools)
 
+set(CMAKE_CXX_STANDARD 11)
+
 add_subdirectory(ibize)

--- a/ibize/blockstream.cpp
+++ b/ibize/blockstream.cpp
@@ -5,7 +5,7 @@
 #pragma warning(disable : 4100)  //unref formal parm
 #pragma warning(disable : 4710)  //member not inlined
 
-#include <string.h>
+#include <cstring>
 #include "blockstream.h"
 
 /*

--- a/ibize/blockstream.h
+++ b/ibize/blockstream.h
@@ -5,10 +5,12 @@
 
 #pragma warning(disable : 4786)  //identifier was truncated 
 
-#include <stdio.h>
-
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 #include <list>
 #include <vector>
+
 using namespace std;
 
 #define	IBI_EXT			".IBI"	//(I)nterpreted (B)lock (I)nstructions

--- a/ibize/ibize_platform.h
+++ b/ibize/ibize_platform.h
@@ -5,7 +5,9 @@
 #if defined(_WINDOWS)
 #include <windows.h>
 #else
-#include <stdint.h>
+#include <cstdint>
+#include <cstring>
+#include <cstddef>
 typedef uint32_t COLORREF;
 #define stricmp strcasecmp
 #define RGB(r,g,b)          ((COLORREF)((r) | ((g) << 8) | ((b) << 16)))

--- a/ibize/interpreter.cpp
+++ b/ibize/interpreter.cpp
@@ -8,7 +8,8 @@
 #else
 #include <unistd.h>
 #endif
-#include <stdio.h>
+#include <cstdarg>
+#include <cstdio>
 
 #include "tokenizer.h"
 #include "blockstream.h"

--- a/ibize/tokenizer.h
+++ b/ibize/tokenizer.h
@@ -10,6 +10,7 @@
 #include <vector>
 #include <map>
 #include <cstdint>
+#include <cstring>
 
 using namespace std;
 


### PR DESCRIPTION
* Paths are case sensitive on Linux and Mac OS system, so specify the correct subdirectory in `CMakeLists.txt`.
* Use the C++11 standard when building with CMake, as e.g. C++17 introduced std::byte which is a conflicting type with the one declared in Ibize.
* Add any missing includes for Ibize to compile with a modern version of GCC, in particular using the standard C++11 or newer.
* Use C++ like include headers instead of C style ones.